### PR TITLE
Remove league/uri-components from composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,6 @@
     },
     "require": {
         "php": ">=7.4",
-        "league/uri-components": "dev-master",
         "spatie/url-signer": "^1.1",
         "symfony/config": "^4.4 || ^5.1",
         "symfony/dependency-injection": "^4.4 || ^5.1",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | N/A
| License       | MIT

Since `spatie/url-signer` 1.2.1, `league/uri-components` is not needed in `dev` stability.