### PR TITLE
Add optional expiration to UrlSignerInterface

### DIFF
--- a/UrlSigner/UrlSignerInterface.php
+++ b/UrlSigner/UrlSignerInterface.php
@@ -17,5 +17,13 @@ use Spatie\UrlSigner\UrlSigner;
 
 interface UrlSignerInterface extends UrlSigner
 {
+    /**
+     * @param string             $url
+     * @param \DateTime|int|null $expiration
+     *
+     * @psalm-suppress MoreSpecificImplementedParamType
+     */
+    public function sign($url, $expiration = null): string;
+
     public static function getName(): string;
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | N/A
| License       | MIT

The `UrlSignerInterface` should have the parameter `$expiration` as optional.