### PR TITLE
feat: enable DateTime in sign constructor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 2.2.0
+
+* Allow to use a date/time string in default expiration time configuration
+
 ## 2.1.0
 
 * Minor **BC break**: use the new classes from `spatie/url-signer` 2.1.0 (`DateTimeInterface` instead of `DateTime` in `sign`)

--- a/DependencyInjection/Compiler/SignerPass.php
+++ b/DependencyInjection/Compiler/SignerPass.php
@@ -54,7 +54,7 @@ final class SignerPass implements CompilerPassInterface
             $signerServiceDefinition = $container->getDefinition($signerServiceId);
             $signerServiceDefinition->setBindings([
                 'string $signatureKey' => '%url_signer.signature_key%',
-                'int $defaultExpiration' => '%url_signer.default_expiration%',
+                '$defaultExpiration' => '%url_signer.default_expiration%',
                 'string $expiresParameter' => '%url_signer.expires_parameter%',
                 'string $signatureParameter' => '%url_signer.signature_parameter%',
             ]);

--- a/README.md
+++ b/README.md
@@ -62,12 +62,22 @@ coop_tilleuls_url_signer:
     signer: 'md5' # 'sha256' by default
 ```
 
-The default expiration time (in seconds) can be changed too:
+The default expiration time can be changed too.
+
+In seconds:
 
 ```yml
 # config/packages/url_signer.yaml
 coop_tilleuls_url_signer:
     default_expiration: 3600 # 86400 by default
+```
+
+With a date/time string:
+
+```yml
+# config/packages/url_signer.yaml
+coop_tilleuls_url_signer:
+    default_expiration: '1 day'
 ```
 
 You can also customize the URL parameter names:

--- a/UrlSigner/AbstractUrlSigner.php
+++ b/UrlSigner/AbstractUrlSigner.php
@@ -17,16 +17,16 @@ use Spatie\UrlSigner\AbstractUrlSigner as SpatieAbstractUrlSigner;
 
 abstract class AbstractUrlSigner extends SpatieAbstractUrlSigner implements UrlSignerInterface
 {
-    private int $defaultExpiration;
+    private \DateTimeInterface|int $defaultExpiration;
 
-    public function __construct(string $signatureKey, int $defaultExpiration, string $expiresParameter, string $signatureParameter)
+    public function __construct(string $signatureKey, int|string $defaultExpiration, string $expiresParameter, string $signatureParameter)
     {
         parent::__construct($signatureKey, $expiresParameter, $signatureParameter);
 
-        $this->defaultExpiration = $defaultExpiration;
+        $this->defaultExpiration = \is_string($defaultExpiration) ? new \DateTimeImmutable($defaultExpiration) : $defaultExpiration;
     }
 
-    public function sign(string $url, int|\DateTimeInterface $expiration = null, string $signatureKey = null): string
+    public function sign(string $url, \DateTimeInterface|int $expiration = null, string $signatureKey = null): string
     {
         return parent::sign($url, $expiration ?? $this->defaultExpiration, $signatureKey);
     }

--- a/UrlSigner/UrlSignerInterface.php
+++ b/UrlSigner/UrlSignerInterface.php
@@ -17,7 +17,7 @@ use Spatie\UrlSigner\Contracts\UrlSigner;
 
 interface UrlSignerInterface extends UrlSigner
 {
-    public function sign(string $url, int|\DateTimeInterface $expiration, string $signatureKey = null): string;
+    public function sign(string $url, \DateTimeInterface|int $expiration, string $signatureKey = null): string;
 
     public static function getName(): string;
 }

--- a/features/app/config/packages/url_signer.yaml
+++ b/features/app/config/packages/url_signer.yaml
@@ -1,2 +1,3 @@
 coop_tilleuls_url_signer:
     signature_key: '%env(string:SIGNATURE_KEY)%'
+    default_expiration: '2 days'

--- a/tests/DependencyInjection/Compiler/SignerPassTest.php
+++ b/tests/DependencyInjection/Compiler/SignerPassTest.php
@@ -53,7 +53,7 @@ final class SignerPassTest extends TestCase
         ]);
         $bindings = [
             'string $signatureKey' => '%url_signer.signature_key%',
-            'int $defaultExpiration' => '%url_signer.default_expiration%',
+            '$defaultExpiration' => '%url_signer.default_expiration%',
             'string $expiresParameter' => '%url_signer.expires_parameter%',
             'string $signatureParameter' => '%url_signer.signature_parameter%',
         ];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no 
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix #12 
| License       | MIT
Add the possibility of DateTime in the constructor (defaultExpiration)


Waiting for merge of https://github.com/spatie/url-signer/pull/45