### PR TITLE
feat: use the new spatie classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 2.1.0
+
+* Minor **BC break**: use the new classes from `spatie/url-signer` 2.1.0 (`DateTimeInterface` instead of `DateTime` in `sign`)
+
 ## 2.0.0
 
 * Upgrade to `spatie/url-signer` 2.x

--- a/UrlSigner/AbstractUrlSigner.php
+++ b/UrlSigner/AbstractUrlSigner.php
@@ -13,9 +13,9 @@ declare(strict_types=1);
 
 namespace CoopTilleuls\UrlSignerBundle\UrlSigner;
 
-use Spatie\UrlSigner\BaseUrlSigner;
+use Spatie\UrlSigner\AbstractUrlSigner as SpatieAbstractUrlSigner;
 
-abstract class AbstractUrlSigner extends BaseUrlSigner implements UrlSignerInterface
+abstract class AbstractUrlSigner extends SpatieAbstractUrlSigner implements UrlSignerInterface
 {
     private int $defaultExpiration;
 
@@ -26,7 +26,7 @@ abstract class AbstractUrlSigner extends BaseUrlSigner implements UrlSignerInter
         $this->defaultExpiration = $defaultExpiration;
     }
 
-    public function sign(string $url, int|\DateTime $expiration = null, string $signatureKey = null): string
+    public function sign(string $url, int|\DateTimeInterface $expiration = null, string $signatureKey = null): string
     {
         return parent::sign($url, $expiration ?? $this->defaultExpiration, $signatureKey);
     }

--- a/UrlSigner/UrlSignerInterface.php
+++ b/UrlSigner/UrlSignerInterface.php
@@ -13,11 +13,11 @@ declare(strict_types=1);
 
 namespace CoopTilleuls\UrlSignerBundle\UrlSigner;
 
-use Spatie\UrlSigner\UrlSigner;
+use Spatie\UrlSigner\Contracts\UrlSigner;
 
 interface UrlSignerInterface extends UrlSigner
 {
-    public function sign(string $url, int|\DateTime $expiration, string $signatureKey = null): string;
+    public function sign(string $url, int|\DateTimeInterface $expiration, string $signatureKey = null): string;
 
     public static function getName(): string;
 }

--- a/tests/UrlSigner/AbstractUrlSignerTest.php
+++ b/tests/UrlSigner/AbstractUrlSignerTest.php
@@ -38,9 +38,9 @@ final class AbstractUrlSignerTest extends TestCase
                 return "{$url}::{$expiration}::{$signatureKey}";
             }
 
-            protected function getExpirationTimestamp(int|\DateTime $expirationInSeconds): string
+            protected function getExpirationTimestamp(int|\DateTimeInterface $expirationInSeconds): string
             {
-                return $expirationInSeconds instanceof \DateTime ? 'datetime' : (string) $expirationInSeconds;
+                return $expirationInSeconds instanceof \DateTimeInterface ? 'datetime' : (string) $expirationInSeconds;
             }
         };
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | N/A
| License       | MIT

Use the new classes from `spatie/url-signer` 2.1.0 (`DateTimeInterface` instead of `DateTime` in `sign`).

It's a minor **BC break** since `AbstractUrlSigner` and `UrlSignerInterface` has changed their signature.