### PR TITLE
Compatibility with Symfony Clock

### DIFF
--- a/UrlSigner/AbstractUrlSigner.php
+++ b/UrlSigner/AbstractUrlSigner.php
@@ -14,9 +14,12 @@ declare(strict_types=1);
 namespace CoopTilleuls\UrlSignerBundle\UrlSigner;
 
 use Spatie\UrlSigner\AbstractUrlSigner as SpatieAbstractUrlSigner;
+use Symfony\Component\Clock\ClockAwareTrait;
 
 abstract class AbstractUrlSigner extends SpatieAbstractUrlSigner implements UrlSignerInterface
 {
+    use ClockAwareTrait;
+
     private \DateTimeInterface|int $defaultExpiration;
 
     public function __construct(string $signatureKey, int|string $defaultExpiration, string $expiresParameter, string $signatureParameter)
@@ -30,5 +33,10 @@ abstract class AbstractUrlSigner extends SpatieAbstractUrlSigner implements UrlS
     public function sign(string $url, \DateTimeInterface|int|null $expiration = null, ?string $signatureKey = null): string
     {
         return parent::sign($url, $expiration ?? $this->defaultExpiration, $signatureKey);
+    }
+
+    protected function isFuture(int $timestamp): bool
+    {
+        return $timestamp >= $this->now()->getTimestamp();
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,8 @@
     "require": {
         "php": ">=8.1",
         "spatie/url-signer": "^2.0",
-        "symfony/config": "^4.4 || ^5.1 || ^6.0 || ^7.0",
+        "symfony/config": "^6.4 || ^7.0",
+        "symfony/clock": "^6.4 || ^7.0",
         "symfony/dependency-injection": "^4.4 || ^5.1 || ^6.0 || ^7.0",
         "symfony/event-dispatcher": "^4.4 || ^5.1 || ^6.0 || ^7.0",
         "symfony/http-kernel": "^4.4 || ^5.1 || ^6.0 || ^7.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix #... 
| License       | MIT

Symfony creates a [Clock component](https://symfony.com/doc/current/components/clock.html) to mock the current time in tests
`isFuture` method must be aware of the mocked time to ensure compatibility with this feature.

I understand that this breaks the compatibility with Symfony version older than 6.4.